### PR TITLE
Added textcontains SQL to  autocomplete field

### DIFF
--- a/WebApp/App_Code/Services/SearchPanelHandler.cs
+++ b/WebApp/App_Code/Services/SearchPanelHandler.cs
@@ -85,6 +85,9 @@ public class SearchPanelHandler : WebServiceHandler
       switch (searchInputFieldRow.FieldType)
       {
         case "autocomplete":
+         where.Add(searchInputFieldRow.ColumnName + " like ?");
+          parameters.Add("%" + criteria[criteriaID].ToString() + "%");
+          break;
         case "date":
         case "list":
         case "number":


### PR DESCRIPTION
Autocomplete is a good field entry mechanism in search panel but if the user types quickly or hits enter prior to selection from autocomplete dropdown no results given. Adding the textcontains component allows it to work in both auto and textcontains mechanism. 